### PR TITLE
2.0 automount creds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN pip install --upgrade pip
 RUN apt-get -y install git
 
 WORKDIR /graphgrid-sdk-python-examples
-COPY sdk_calls.py sdk_calls.py
-COPY requirements.txt requirements.txt
-COPY dataset_example.jsonl dataset_example.jsonl
+COPY airflow-dag-sample/sdk_calls.py sdk_calls.py
+COPY airflow-dag-sample/requirements.txt requirements.txt
+COPY airflow-dag-sample/dataset_example.jsonl dataset_example.jsonl
 
 RUN python3 -m pip install -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We need to build a docker image based on our dockerfile.
 This image is what Airflow uses when the DAG is triggered.   
 
 ```bash
-docker build -t sdk-graphgrid-sdk-python-examples -f graphgrid-sdk-python-example.dockerfile .
+docker build -t graphgrid-sdk-python-examples .
 ```
 
 # Upload your DAG

--- a/airflow-dag-sample/example_dag.py
+++ b/airflow-dag-sample/example_dag.py
@@ -4,7 +4,7 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator
 from docker import APIClient
 from graphgrid_provider.operators.graphgrid_docker import \
-    GraphGridDockerOperator, GraphgridMount
+    GraphGridDockerOperator, GraphGridMount
 
 DOCKER_URL = "tcp://socat:2375"
 SOURCE = "{{ ti.xcom_pull(task_ids='create_volume') }}"
@@ -69,7 +69,7 @@ t_create_volume = PythonOperator(python_callable=create_volume,
 
 t_1 = GraphGridDockerOperator(task_id='save_dataset',
                               dag=dag,
-                              mounts=[GraphgridMount(target="/config/",
+                              mounts=[GraphGridMount(target="/volumes/",
                                                      source=SOURCE)],
                               image="graphgrid-sdk-python-examples",
                               command=["save_dataset",
@@ -81,7 +81,7 @@ t_1 = GraphGridDockerOperator(task_id='save_dataset',
 
 t_2 = GraphGridDockerOperator(task_id='train_and_promote',
                               dag=dag,
-                              mounts=[GraphgridMount(target="/config/",
+                              mounts=[GraphGridMount(target="/volumes/",
                                                      source=SOURCE)],
                               image="graphgrid-sdk-python-examples",
                               command=["train_and_promote",

--- a/airflow-dag-sample/example_dag.py
+++ b/airflow-dag-sample/example_dag.py
@@ -9,8 +9,8 @@ from graphgrid_provider.operators.graphgrid_docker import \
 DOCKER_URL = "tcp://socat:2375"
 SOURCE = "{{ ti.xcom_pull(task_ids='create_volume') }}"
 dataset_filepath = 'dataset_example.jsonl'
-dataset_name = 'sample_dataset'
-models_to_train = '["named_entity_recognition", "pos_tagging"]'
+filename = 'sample_dataset'
+models_to_train = '["named_entity_recognition", "part_of_speech_tagging"]'
 
 
 def read_by_line():
@@ -74,8 +74,7 @@ t_1 = GraphGridDockerOperator(task_id='save_dataset',
                               image="graphgrid-sdk-python-examples",
                               command=["save_dataset",
                                        "--dataset_filepath", dataset_filepath,
-                                       "--dataset_name", dataset_name,
-                                       "--overwrite", 'false'],
+                                       "--filename", filename],
                               auto_remove=True,
                               )
 
@@ -86,7 +85,8 @@ t_2 = GraphGridDockerOperator(task_id='train_and_promote',
                               image="graphgrid-sdk-python-examples",
                               command=["train_and_promote",
                                        "--models_to_train", models_to_train,
-                                       "--datasets", dataset_name + '.jsonl',
+                                       "--datasetId",
+                                       "{{ ti.xcom_pull(task_ids='save_dataset') }}",
                                        "--no_cache", 'false',
                                        "--gpu", 'false',
                                        "--autopromote", 'true'],

--- a/airflow-dag-sample/requirements.txt
+++ b/airflow-dag-sample/requirements.txt
@@ -1,5 +1,5 @@
 graphgrid-sdk==2.0.0
-airflow-provider-graphgrid==2.0.0
+airflow-provider-graphgrid==2.0.1
 
 apache-airflow==2.2.2
 

--- a/airflow-dag-sample/requirements.txt
+++ b/airflow-dag-sample/requirements.txt
@@ -1,4 +1,4 @@
-graphgrid-sdk
+graphgrid-sdk==2.0.0
 airflow-provider-graphgrid==2.0.0
 
 apache-airflow==2.2.2
@@ -13,4 +13,3 @@ pytz==2021.1
 six==1.15.0
 boto3==1.17.27
 fire==0.4.0
-airflow-provider-graphgrid==2.0.0

--- a/airflow-dag-sample/sdk_calls.py
+++ b/airflow-dag-sample/sdk_calls.py
@@ -7,8 +7,7 @@ from graphgrid_sdk.ggsdk.sdk import GraphGridSdk
 
 class Pipeline:
 
-    def save_dataset(self, dataset_filepath: str, dataset_name: str,
-                     overwrite: bool):
+    def save_dataset(self, dataset_filepath: str, filename: str):
         sdk = GraphGridSdk()
 
         def read_by_line(dataset_filepath):
@@ -20,14 +19,15 @@ class Pipeline:
 
         yield_function = read_by_line(dataset_filepath)
         dataset_response: SaveDatasetResponse = sdk.save_dataset(yield_function,
-                                                                 dataset_name,
-                                                                 overwrite)
+                                                                 filename)
         if dataset_response.status_code != 200:
             raise Exception("Failed to save dataset: ",
                             dataset_response.exception)
 
+        return dataset_response.datasetId
+
     def train_and_promote(self, models_to_train: list,
-                          datasets: typing.Union[str, list],
+                          datasetId: str,
                           no_cache: typing.Optional[bool],
                           gpu: typing.Optional[bool], autopromote: bool):
         sdk = GraphGridSdk()
@@ -38,7 +38,7 @@ class Pipeline:
         def failed_handler(args):
             return
 
-        sdk.nmt_train_pipeline(models_to_train, datasets, no_cache, gpu,
+        sdk.nmt_train_pipeline(models_to_train, datasetId, no_cache, gpu,
                                autopromote, success_handler, failed_handler)
 
 

--- a/airflow-dag-sample/sdk_calls.py
+++ b/airflow-dag-sample/sdk_calls.py
@@ -1,8 +1,6 @@
-import time
+import typing
 
 import fire
-import typing
-from graphgrid_sdk.ggcore.config import SdkBootstrapConfig
 from graphgrid_sdk.ggcore.sdk_messages import SaveDatasetResponse
 from graphgrid_sdk.ggsdk.sdk import GraphGridSdk
 
@@ -11,11 +9,7 @@ class Pipeline:
 
     def save_dataset(self, dataset_filepath: str, dataset_name: str,
                      overwrite: bool):
-        sdk = GraphGridSdk(SdkBootstrapConfig(
-            access_key='a3847750f486bd931de26c6e683b1dc4',
-            secret_key='81a62cea53883f4a163a96355d47656e',
-            url_base='localhost',
-            is_docker_context=True))
+        sdk = GraphGridSdk()
 
         def read_by_line(dataset_filepath):
             infile = open(
@@ -36,11 +30,7 @@ class Pipeline:
                           datasets: typing.Union[str, list],
                           no_cache: typing.Optional[bool],
                           gpu: typing.Optional[bool], autopromote: bool):
-        sdk = GraphGridSdk(SdkBootstrapConfig(
-            access_key='a3847750f486bd931de26c6e683b1dc4',
-            secret_key='81a62cea53883f4a163a96355d47656e',
-            url_base='localhost',
-            is_docker_context=True))
+        sdk = GraphGridSdk()
 
         def success_handler(args):
             return


### PR DESCRIPTION
rebased on top of the Dockerfile fixes PR, so that should be merged first
This is PR is also dependent on the following PRs:

graphgrid-sdk-python -- 2.0-datasetId -- [link](https://github.com/graphgrid/graphgrid-sdk-python/pull/28)
airflow-provider-graphgrid -- 2.0-bump-version -- [link](https://github.com/graphgrid/airflow-provider-graphgrid/pull/3)

So those should also be merged in first 

Changelist:
* Fix `pos_tagging` -> `part_of_speech_tagging`
* Switch to `datasetId` rather than datasets usage
* Switch mount location for data propagation to `/volumes/`
* Switch to propagating `datasetId` to downstream nmt pipeline task via XCOM
* Bump provider version to 2.0.1
* Switch to auotmounting ("automagic") credentials usage